### PR TITLE
fix(layout): caret indicator overflow

### DIFF
--- a/static/css/cursortrace.css
+++ b/static/css/cursortrace.css
@@ -29,6 +29,22 @@ div.stickUp:before{
   margin-top:-6px;
 }
 
+div.stickRight{     /* slide everything up a little bit, so it doesn't hide what is being written */
+  margin-top:-5px;
+}
+
+div.stickRight:before{
+  content: "";
+  display: block;
+  width: 2px;
+  height: 28px;
+  background-color: black;
+  opacity:.5;
+  margin-left: auto;
+  margin-right: -2px;
+  margin-top:-2px;
+}
+
 div.stickDown:before{
   content: "";
   display: block;
@@ -48,6 +64,13 @@ p.stickUp{
   padding-right:4px;
 }
 
+p.stickRight{
+  position:relative;
+  top:2px;
+  margin-top:-31px;
+  padding-left:4px;
+  padding-right:4px;
+}
 
 p.stickDown{
   position:relative;


### PR DESCRIPTION
Switch stick to right when name does not fit on the screen

**Caret always at the left**
![before](https://user-images.githubusercontent.com/32987232/122940961-51019c00-d34b-11eb-8099-d9923fdd9ba8.gif)

**Caret switching to right when name doesn't fit on screen**
![after](https://user-images.githubusercontent.com/32987232/122940977-54952300-d34b-11eb-8c2d-95f456d4b833.gif)

