### PR TITLE
fix: account for outerdocbody padding so cursors don't drift on mobile (#60, partial)

### DIFF
--- a/static/js/main.js
+++ b/static/js/main.js
@@ -118,6 +118,12 @@ exports.handleClientMessage_CUSTOM = (hook, context, cb) => {
 
       // We need the offset of the innerdocbody on top too.
       top += parseInt($('iframe[name="ace_outer"]').contents().find('iframe').css('paddingTop'));
+      // Also account for #outerdocbody padding-top. On desktop layout this
+      // is 20px (set by Etherpad core) and the plugin was implicitly
+      // relying on that constant; on mobile-layout it's 0, so other
+      // users' cursors drifted ~20px down on narrow screens (#60).
+      const $outerBody = $('iframe[name="ace_outer"]').contents().find('#outerdocbody');
+      top += parseInt($outerBody.css('paddingTop'), 10) || 0;
 
       // Get the HTML
       const html = $(div).html();


### PR DESCRIPTION
Partial fix for #60. Etherpad's `#outerdocbody` has `padding-top: 20px` on desktop layout and `0` on mobile-layout. The plugin was implicitly assuming the 20px constant when calculating where to draw remote cursors, so on narrow screens the caret indicator drew ~20px too low. Add the measured padding to the top offset.

Leaves the off-by-one column and line-height drift on wrapped lines that #60 also calls out — those need more careful multi-client testing and will be addressed separately.