### PR TITLE
chore(deps): bump ep_plugin_helpers to ^0.6.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,6 @@
     "lint:fix": "eslint --fix ."
   },
   "dependencies": {
-    "ep_plugin_helpers": "^0.5.3"
+    "ep_plugin_helpers": "^0.6.0"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,8 +9,8 @@ importers:
   .:
     dependencies:
       ep_plugin_helpers:
-        specifier: ^0.5.3
-        version: 0.5.3
+        specifier: ^0.6.0
+        version: 0.6.2
     devDependencies:
       eslint:
         specifier: ^8.57.1
@@ -186,31 +186,37 @@ packages:
     resolution: {integrity: sha512-p+s/Wp8rf75Qqs2EPw4HC0xVLLW+/60MlVAsB7TYLoeg1e1CU/QCis36FxpziLS0ZY2+wXdTnPUxr+5kkThzwQ==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/rspack-resolver-binding-linux-arm64-musl@1.3.0':
     resolution: {integrity: sha512-cZEL9jmZ2kAN53MEk+fFCRJM8pRwOEboDn7sTLjZW+hL6a0/8JNfHP20n8+MBDrhyD34BSF4A6wPCj/LNhtOIQ==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@unrs/rspack-resolver-binding-linux-ppc64-gnu@1.3.0':
     resolution: {integrity: sha512-IOeRhcMXTNlk2oApsOozYVcOHu4t1EKYKnTz4huzdPyKNPX0Y9C7X8/6rk4aR3Inb5s4oVMT9IVKdgNXLcpGAQ==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/rspack-resolver-binding-linux-s390x-gnu@1.3.0':
     resolution: {integrity: sha512-op54XrlEbhgVRCxzF1pHFcLamdOmHDapwrqJ9xYRB7ZjwP/zQCKzz/uAsSaAlyQmbSi/PXV7lwfca4xkv860/Q==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/rspack-resolver-binding-linux-x64-gnu@1.3.0':
     resolution: {integrity: sha512-orbQF7sN02N/b9QF8Xp1RBO5YkfI+AYo9VZw0H2Gh4JYWSuiDHjOPEeFPDIRyWmXbQJuiVNSB+e1pZOjPPKIyg==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/rspack-resolver-binding-linux-x64-musl@1.3.0':
     resolution: {integrity: sha512-kpjqjIAC9MfsjmlgmgeC8U9gZi6g/HTuCqpI7SBMjsa7/9MvBaQ6TJ7dtnsV/+DXvfJ2+L5teBBXG+XxfpvIFA==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@unrs/rspack-resolver-binding-wasm32-wasi@1.3.0':
     resolution: {integrity: sha512-JAg0hY3kGsCPk7Jgh16yMTBZ6VEnoNR1DFZxiozjKwH+zSCfuDuM5S15gr50ofbwVw9drobIP2TTHdKZ15MJZQ==}
@@ -399,8 +405,8 @@ packages:
     resolution: {integrity: sha512-Qohcme7V1inbAfvjItgw0EaxVX5q2rdVEZHRBrEQdRZTssLDGsL8Lwrznl8oQ/6kuTJONLaDcGjkNP247XEhcA==}
     engines: {node: '>=10.13.0'}
 
-  ep_plugin_helpers@0.5.3:
-    resolution: {integrity: sha512-L/8ALIvQYUcwzC2ZUdkC5Vy50TQ4N41t8ektL/pVDOuvU593YwD8kLXNVa/9LFTccOPmTugub53VdFXUDLl0ug==}
+  ep_plugin_helpers@0.6.2:
+    resolution: {integrity: sha512-CGWdFk6FG0Q0y1opoly+J4tkNpSOI2Tho4oOmaWCpMwgJxvdO4W/i5LIZQXLDSGoRCuAUKokd3H/fvEqTjztgw==}
     engines: {node: '>=18.0.0'}
 
   es-abstract@1.24.2:
@@ -1676,7 +1682,7 @@ snapshots:
       graceful-fs: 4.2.11
       tapable: 2.3.2
 
-  ep_plugin_helpers@0.5.3: {}
+  ep_plugin_helpers@0.6.2: {}
 
   es-abstract@1.24.2:
     dependencies:


### PR DESCRIPTION
## Why
Caret semver on pre-1.0 versions pins the minor, so `^0.5.x` doesn't accept any 0.6.x release. Without this bump, fresh installs of this plugin resolve `ep_plugin_helpers@0.5.3` and miss fixes shipped in 0.6.x — most recently ether/ep_plugin_helpers#19 which corrected the misleading "Etherpad < 2.7.4" degradation warning that surfaced for thm on a 3.1.0 deployment.

## What
- Bump `dependencies.ep_plugin_helpers` from `^0.5.3` to `^0.6.0`
- Plugin CI gates any behavioural break.

🤖 Generated with [Claude Code](https://claude.com/claude-code)